### PR TITLE
Fix login logout state

### DIFF
--- a/lib/app/(public)/login_page.dart
+++ b/lib/app/(public)/login_page.dart
@@ -40,7 +40,8 @@ class _LoginPageState extends State<LoginPage> {
                     children: [
                       const Text('Você está logado!'),
                       ElevatedButton(
-                        onPressed: () {
+                        onPressed: () async {
+                          await signOut();
                         },
                         child: const Text('Logout'),
                       ),

--- a/lib/app/data/repositories/user/auth_repository.dart
+++ b/lib/app/data/repositories/user/auth_repository.dart
@@ -30,15 +30,26 @@ class FirebaseAuthRepository implements AuthRepository {
           await _firebaseAuth.signInWithCredential(credential);
 
       if (userCredential.additionalUserInfo?.isNewUser ?? false) {
+        authState.value = true;
         Routefly.navigate(routePaths.updateUser);
         return true;
       }
 
+      authState.value = true;
       Routefly.navigate(routePaths.home);
       return true;
     } catch (e) {
       throw Exception("Erro ao atualizar usuário");
     }
+  }
+
+  @override
+  Future<void> signOut() async {
+    await _firebaseAuth.signOut();
+    await _googleSignIn.signOut();
+    authState.value = false;
+    userState.value = null;
+    Routefly.navigate(routePaths.login);
   }
 
    @override

--- a/lib/app/interactor/user/actions/auth_action.dart
+++ b/lib/app/interactor/user/actions/auth_action.dart
@@ -20,3 +20,8 @@ Future<UserModel> getDataUser() async {
   final repository = injector.get<AuthRepository>();
   return await repository.getDataUser();
 }
+
+Future<void> signOut() async {
+  final repository = injector.get<AuthRepository>();
+  await repository.signOut();
+}

--- a/lib/app/interactor/user/repositories/auth_repository.dart
+++ b/lib/app/interactor/user/repositories/auth_repository.dart
@@ -5,4 +5,5 @@ abstract class AuthRepository {
   Future<bool> signInWithGoogle();
   Future<void> createDataUser(UpdateUserModel user);
   Future<UserModel> getDataUser();
+  Future<void> signOut();
 }


### PR DESCRIPTION
## Summary
- add a signOut contract to `AuthRepository`
- implement signOut in `FirebaseAuthRepository`
- expose signOut action
- wire logout button to signOut and update auth state when logging in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684047bcaf1083268123d135e3699d8f